### PR TITLE
Next major version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18, 20, 21]
+        node: [18, 20, 22]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -2,11 +2,16 @@
 
 ## Core
 
+### Adapters
+
 - [`mutent-array`](https://github.com/greguz/mutent-array) Simple in memory array adapter.
+- [`mutent-couchdb`](https://github.com/greguz/mutent-couchdb) CouchDB adapter for Mutent.
+- [`mutent-mongodb`](https://github.com/greguz/mutent-mongodb) MongoDB adapter for Mutent.
+
+### Plugins
+
 - [`mutent-json-schema`](https://github.com/greguz/mutent-json-schema) JSON Schema validation plugin with [Ajv](https://github.com/ajv-validator/ajv).
 - [`mutent-migration`](https://github.com/greguz/mutent-migration) Data versioning and migration for Mutent.
-- [`mutent-mongodb`](https://github.com/greguz/mutent-mongodb) MongoDB adapter for Mutent.
-- [`mutent-couchdb`](https://github.com/greguz/mutent-couchdb) CouchDB adapter for Mutent.
 
 <!--
 ## Community

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ Let's create a simple [Store](./store.md) instance that uses an Array as Datasto
 
 ```javascript
 import { Store } from 'mutent'
-import { ArrayAdapter } from 'mutent-array'
+import ArrayAdapter from 'mutent-array'
 
 const store = new Store({
   adapter: new ArrayAdapter()
@@ -109,15 +109,3 @@ const deleted = await store
 console.log(deleted) // { id: 42, name: 'Towel', updatedAt: ISODate }
 console.log(store.adapter.items) // []
 ```
-
-## Sections
-
-1. [Store](./store.md)
-2. [Adapter](./adapter.md)
-3. [Entity](./entity.md)
-4. [Mutation](./mutation.md)
-5. [Mutator](./mutator.md)
-6. [Context](./context.md)
-7. [Hooks](./hooks.md)
-8. [Errors](./errors.md)
-9. [Ecosystem](./ecosystem.md)

--- a/lib/adapter.mjs
+++ b/lib/adapter.mjs
@@ -1,4 +1,5 @@
 import { MutentError } from './error.mjs'
+import { isFunction } from './util.mjs'
 
 /**
  * Return the customized Adapter's name (if any) or something descriptive
@@ -13,15 +14,14 @@ export function getAdapterName (adapter) {
 async function * findEntity (ctx) {
   const { adapter, argument, hooks, intent, options } = ctx
 
-  if (!adapter.find) {
+  if (!isFunction(adapter.find) && !isFunction(adapter.findEntity)) {
     throw new MutentError(
       'EMUT_PARTIAL_ADAPTER',
-      'The adapter does not implement ".find" method',
+      'The adapter does not implement both ".find" and ".findEntity" methods',
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
@@ -30,7 +30,9 @@ async function * findEntity (ctx) {
     await hook(argument, ctx)
   }
 
-  const data = await adapter.find(argument, options)
+  const data = isFunction(adapter.findEntity)
+    ? await adapter.findEntity(argument, ctx)
+    : await adapter.find(argument, options)
 
   if (data !== null && data !== undefined) {
     yield data
@@ -40,15 +42,14 @@ async function * findEntity (ctx) {
 async function * filterEntities (ctx) {
   const { adapter, argument, hooks, intent, options } = ctx
 
-  if (!adapter.filter) {
+  if (!isFunction(adapter.filter) && !isFunction(adapter.filterEntities)) {
     throw new MutentError(
       'EMUT_PARTIAL_ADAPTER',
-      'The adapter does not implement ".filter" method',
+      'The adapter does not implement both ".filter" and ".filterEntities" methods',
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
@@ -57,7 +58,11 @@ async function * filterEntities (ctx) {
     await hook(argument, ctx)
   }
 
-  yield * adapter.filter(argument, options)
+  if (isFunction(adapter.filterEntities)) {
+    yield * adapter.filterEntities(argument, ctx)
+  } else {
+    yield * adapter.filter(argument, options)
+  }
 }
 
 export function iterateContext (ctx) {
@@ -87,15 +92,14 @@ async function * asIterable (argument) {
 async function createEntity (entity, ctx) {
   const { adapter, argument, hooks, intent, options } = ctx
 
-  if (!adapter.create && !adapter.createEntity) {
+  if (!isFunction(adapter.create) && !isFunction(adapter.createEntity)) {
     throw new MutentError(
       'EMUT_PARTIAL_ADAPTER',
       'The Adapter does not implement both the ".create" and ".createEntity" methods',
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
@@ -104,7 +108,7 @@ async function createEntity (entity, ctx) {
     await hook(entity, ctx)
   }
 
-  if (adapter.createEntity) {
+  if (isFunction(adapter.createEntity)) {
     await adapter.createEntity(entity, ctx)
   } else {
     const result = await adapter.create(entity.target, options)
@@ -121,15 +125,14 @@ async function createEntity (entity, ctx) {
 async function updateEntity (entity, ctx) {
   const { adapter, argument, hooks, intent, options } = ctx
 
-  if (!adapter.update && !adapter.updateEntity) {
+  if (!isFunction(adapter.update) && !isFunction(adapter.updateEntity)) {
     throw new MutentError(
       'EMUT_PARTIAL_ADAPTER',
       'The Adapter does not implement both the ".update" and ".updateEntity" methods',
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
@@ -138,7 +141,7 @@ async function updateEntity (entity, ctx) {
     await hook(entity, ctx)
   }
 
-  if (adapter.updateEntity) {
+  if (isFunction(adapter.updateEntity)) {
     await adapter.updateEntity(entity, ctx)
   } else {
     const result = await adapter.update(entity.source, entity.target, options)
@@ -155,15 +158,14 @@ async function updateEntity (entity, ctx) {
 async function deleteEntity (entity, ctx) {
   const { adapter, argument, hooks, intent, options } = ctx
 
-  if (!adapter.delete && !adapter.deleteEntity) {
+  if (!isFunction(adapter.delete) && !isFunction(adapter.deleteEntity)) {
     throw new MutentError(
       'EMUT_PARTIAL_ADAPTER',
       'The Adapter does not implement both the ".delete" and ".deleteEntity" methods',
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
@@ -172,7 +174,7 @@ async function deleteEntity (entity, ctx) {
     await hook(entity, ctx)
   }
 
-  if (adapter.deleteEntity) {
+  if (isFunction(adapter.deleteEntity)) {
     await adapter.deleteEntity(entity, ctx)
   } else {
     await adapter.delete(entity.source, options)
@@ -207,42 +209,37 @@ export async function * concurrentWrite (iterable, ctx) {
   const { writeSize } = ctx
 
   let buffer = []
+
   for await (const entity of iterable) {
     buffer.push(entity)
 
     if (buffer.length >= writeSize) {
-      const results = await Promise.all(
-        buffer.map(item => writeEntity(item, ctx))
+      yield * await Promise.all(
+        buffer.map(e => writeEntity(e, ctx))
       )
-      for (const result of results) {
-        yield result
-      }
       buffer = []
     }
   }
+
   if (buffer.length > 0) {
-    const results = await Promise.all(
-      buffer.map(item => writeEntity(item, ctx))
+    yield * await Promise.all(
+      buffer.map(e => writeEntity(e, ctx))
     )
-    for (const result of results) {
-      yield result
-    }
     buffer = []
   }
 }
 
 export async function * bulkWrite (iterable, ctx) {
-  const { adapter, argument, hooks, intent, options, writeSize } = ctx
+  const { adapter, argument, hooks, intent, writeSize } = ctx
 
-  if (!adapter.bulk && !adapter.bulkEntities) {
+  if (!isFunction(adapter.bulk) && !isFunction(adapter.bulkEntities)) {
     throw new MutentError(
       'EMUT_PARTIAL_ADAPTER',
       'The Adapter does not implement both the ".bulk" and ".bulkEntities" methods',
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
@@ -337,7 +334,7 @@ async function * flushQueue (queue, ctx) {
 
   const pending = queue.filter(e => e.shouldCommit)
   if (pending.length > 0) {
-    if (adapter.bulkEntities) {
+    if (isFunction(adapter.bulkEntities)) {
       await adapter.bulkEntities(pending, ctx)
     } else {
       const result = Object(

--- a/lib/mutation.mjs
+++ b/lib/mutation.mjs
@@ -7,6 +7,8 @@ import {
   ddelete,
   ensure,
   filter,
+  limit,
+  skip,
   tap,
   update
 } from './mutators.mjs'
@@ -18,12 +20,13 @@ import {
   parseWriteMode,
   parseWriteSize
 } from './options.mjs'
-import { isAsyncIterable, isIterable } from './util.mjs'
+import { isAsyncIterable, isIterable, isObjectLike } from './util.mjs'
 
 export class Mutation {
-  constructor (context, mutators = []) {
-    this._context = context
+  constructor (ctx, mutators = []) {
+    this._ctx = ctx
     this._mutators = mutators
+    this.mutable = false
   }
 
   assign (...objects) {
@@ -43,8 +46,8 @@ export class Mutation {
     return this.pipe(commit())
   }
 
-  delete () {
-    return this.pipe(ddelete())
+  delete (predicate) {
+    return this.pipe(ddelete(predicate))
   }
 
   ensure (one) {
@@ -57,13 +60,29 @@ export class Mutation {
 
   iterate (options) {
     return iterateMethod(
-      prepareContext(this._context, options),
-      this._mutators.concat(mutatorClose)
+      prepareContext(this._ctx, options),
+      this._mutators
     )
   }
 
+  limit (n) {
+    return this.pipe(limit(n))
+  }
+
   pipe (...mutators) {
-    return new Mutation(this._context, this._mutators.concat(mutators))
+    if (this.mutable) {
+      this._mutators.push(...mutators)
+      return this
+    }
+
+    return new Mutation(
+      this._ctx,
+      this._mutators.concat(mutators)
+    )
+  }
+
+  skip (n) {
+    return this.pipe(skip(n))
   }
 
   tap (callback) {
@@ -72,8 +91,8 @@ export class Mutation {
 
   unwrap (options) {
     return unwrapMethod(
-      prepareContext(this._context, options),
-      this._mutators.concat(mutatorClose)
+      prepareContext(this._ctx, options),
+      this._mutators
     )
   }
 
@@ -92,40 +111,38 @@ function isMultiple (intent, argument) {
   }
 }
 
-function prepareContext (context, unwrapOptions) {
-  const { adapter, argument, intent } = context
+function prepareContext (ctx, options = {}) {
+  if (!isObjectLike(options)) {
+    throw new TypeError('Unwrap options must be an object')
+  }
 
-  unwrapOptions = Object(unwrapOptions)
-  const mutentOptions = Object(unwrapOptions.mutent)
-
+  const mutentOptions = Object(options.mutent)
   return {
-    adapter,
-    argument,
+    ...ctx,
     commitMode: mutentOptions.commitMode !== undefined
       ? parseCommitMode(mutentOptions.commitMode)
-      : context.commitMode,
-    handlers: context.handlers.concat(
+      : ctx.commitMode,
+    handlers: ctx.handlers.concat(
       normalizeMutators(mutentOptions.handlers)
     ),
-    hooks: mergeHooks(context.hooks, normalizeHooks(mutentOptions.hooks)),
-    intent,
-    multiple: isMultiple(intent, argument),
-    mutators: context.mutators.concat(
+    hooks: mergeHooks(ctx.hooks, normalizeHooks(mutentOptions.hooks)),
+    multiple: isMultiple(ctx.intent, ctx.argument),
+    mutators: ctx.mutators.concat(
       normalizeMutators(mutentOptions.mutators)
     ),
     opaque: mutentOptions.opaque,
-    options: unwrapOptions,
+    options,
     writeMode: mutentOptions.writeMode !== undefined
       ? parseWriteMode(mutentOptions.writeMode)
-      : context.writeMode,
+      : ctx.writeMode,
     writeSize: mutentOptions.writeSize !== undefined
       ? parseWriteSize(mutentOptions.writeSize)
-      : context.writeSize
+      : ctx.writeSize
   }
 }
 
 async function * iterateMethod (ctx, mutators) {
-  const { adapter, argument, intent, multiple, options } = ctx
+  const { adapter, argument, intent, multiple } = ctx
 
   const chain = [
     // Plugins' mutators
@@ -152,8 +169,7 @@ async function * iterateMethod (ctx, mutators) {
         {
           adapter: getAdapterName(adapter),
           intent,
-          argument,
-          options
+          argument
         }
       )
     }
@@ -167,27 +183,26 @@ async function * iterateMethod (ctx, mutators) {
       {
         adapter: getAdapterName(adapter),
         intent,
-        argument,
-        options
+        argument
       }
     )
   }
 }
 
-async function unwrapMethod (context, mutators) {
+async function unwrapMethod (ctx, mutators) {
   const results = []
-  for await (const data of iterateMethod(context, mutators)) {
+  for await (const data of iterateMethod(ctx, mutators)) {
     results.push(data)
   }
-  return context.multiple
+  return ctx.multiple
     ? results
     : results.length > 0
       ? results[0]
       : null
 }
 
-async function * iterateEntities (iterable, context) {
-  const { hooks, intent } = context
+async function * iterateEntities (iterable, ctx) {
+  const { hooks, intent } = ctx
 
   for await (const data of iterable) {
     const entity = intent === 'CREATE'
@@ -195,27 +210,27 @@ async function * iterateEntities (iterable, context) {
       : Entity.read(data)
 
     for (const hook of hooks.onEntity) {
-      await hook(entity, context)
+      await hook(entity, ctx)
     }
 
     yield entity
   }
 }
 
-async function * mutatorClose (iterable, context) {
-  const { commitMode } = context
+async function * mutatorClose (iterable, ctx) {
+  const { commitMode } = ctx
 
   if (commitMode === 'AUTO') {
-    yield * commit()(iterable, context)
+    yield * commit()(iterable, ctx)
   } else if (commitMode === 'MANUAL') {
     yield * iterable
   } else {
-    yield * mutatorSafe(iterable, context)
+    yield * mutatorSafe(iterable, ctx)
   }
 }
 
-async function * mutatorSafe (iterable, context) {
-  const { adapter, argument, intent, options } = context
+async function * mutatorSafe (iterable, ctx) {
+  const { adapter, argument, intent } = ctx
 
   for await (const entity of iterable) {
     if (entity.shouldCommit) {
@@ -226,7 +241,6 @@ async function * mutatorSafe (iterable, context) {
           adapter: getAdapterName(adapter),
           intent,
           argument,
-          options,
           entity
         }
       )

--- a/lib/mutation.spec.mjs
+++ b/lib/mutation.spec.mjs
@@ -4,18 +4,22 @@ import { Mutation } from './mutation.mjs'
 import { assign, pipe, update } from './mutators.mjs'
 import { normalizeHooks } from './options.mjs'
 
-function buildMutation (intent, argument, context = {}) {
+function buildMutation (intent, argument, ctx = {}) {
   return new Mutation({
     adapter: {},
-    argument,
     commitMode: 'AUTO',
     handlers: [],
-    intent,
+    multiple: undefined,
+    mutable: false,
     mutators: [],
+    opaque: undefined,
+    options: {},
     writeMode: 'AUTO',
     writeSize: 16,
-    ...context,
-    hooks: normalizeHooks(context.hooks)
+    ...ctx,
+    argument,
+    hooks: normalizeHooks(ctx.hooks),
+    intent
   })
 }
 

--- a/lib/mutators.mjs
+++ b/lib/mutators.mjs
@@ -1,8 +1,9 @@
 import { bulkWrite, concurrentWrite, sequentialWrite } from './adapter.mjs'
 import { Entity } from './entity.mjs'
+import { isFunction, isPositiveInteger, passthrough } from './util.mjs'
 
 export function ensure (one) {
-  return async function * mutatorEnsure (iterable, context) {
+  return async function * mutatorEnsure (iterable, ctx) {
     let exists = false
     for await (const entity of iterable) {
       exists = true
@@ -11,8 +12,8 @@ export function ensure (one) {
     if (!exists) {
       const data = await (typeof one === 'function' ? one() : one)
       const entity = Entity.create(data)
-      for (const hook of context.hooks.onEntity) {
-        await hook(entity, context)
+      for (const hook of ctx.hooks.onEntity) {
+        await hook(entity, ctx)
       }
       yield entity
     }
@@ -20,6 +21,10 @@ export function ensure (one) {
 }
 
 export function filter (predicate) {
+  if (!isFunction(predicate)) {
+    throw new TypeError('Filter mutator expectes a predicate function')
+  }
+
   return async function * mutatorFilter (iterable) {
     let index = 0
     for await (const entity of iterable) {
@@ -36,14 +41,29 @@ async function * mutatorDelete (iterable) {
   }
 }
 
-export function ddelete () {
-  return mutatorDelete
+export function ddelete (predicate) {
+  if (!predicate) {
+    return mutatorDelete
+  }
+  if (!isFunction(predicate)) {
+    throw new TypeError('Delete mutator expectes a predicate function')
+  }
+
+  return async function * mutatorDeleteConditional (iterable) {
+    let index = 0
+    for await (const entity of iterable) {
+      if (await predicate(entity.valueOf(), index++)) {
+        entity.delete()
+      }
+      yield entity
+    }
+  }
 }
 
-async function * mutatorCommit (iterable, context) {
-  const { adapter, multiple, writeSize } = context
+async function * mutatorCommit (iterable, ctx) {
+  const { adapter, multiple, writeSize } = ctx
 
-  let writeMode = context.writeMode
+  let writeMode = ctx.writeMode
   if (writeMode === 'AUTO' && writeSize >= 2) {
     writeMode = multiple && (adapter.bulk || adapter.bulkEntities)
       ? 'BULK'
@@ -51,11 +71,11 @@ async function * mutatorCommit (iterable, context) {
   }
 
   if (writeMode === 'BULK') {
-    yield * bulkWrite(iterable, context)
+    yield * bulkWrite(iterable, ctx)
   } else if (writeMode === 'CONCURRENT') {
-    yield * concurrentWrite(iterable, context)
+    yield * concurrentWrite(iterable, ctx)
   } else {
-    yield * sequentialWrite(iterable, context)
+    yield * sequentialWrite(iterable, ctx)
   }
 }
 
@@ -64,6 +84,10 @@ export function commit () {
 }
 
 export function update (mapper) {
+  if (!isFunction(mapper)) {
+    throw new TypeError('Update mutator expects a map function')
+  }
+
   return async function * mutatorUpdate (iterable) {
     let index = 0
     for await (const entity of iterable) {
@@ -92,10 +116,45 @@ export function tap (callback) {
 }
 
 export function pipe (...mutators) {
-  return function mutatorPipe (iterable, context) {
+  return function mutatorPipe (iterable, ctx) {
     return mutators.reduce(
-      (accumulator, mutator) => mutator(accumulator, context),
+      (accumulator, mutator) => mutator(accumulator, ctx),
       iterable
     )
+  }
+}
+
+export function skip (n = 0) {
+  if (n === 0) {
+    return passthrough // keep the same iterable
+  }
+  if (!isPositiveInteger(n)) {
+    throw new TypeError('Skip mutator expects a positive integer or zero')
+  }
+
+  return async function * mutatorSkip (iterable) {
+    for await (const entity of iterable) {
+      if (n > 0) {
+        n--
+      } else {
+        yield entity
+      }
+    }
+  }
+}
+
+export function limit (n) {
+  if (!isPositiveInteger(n)) {
+    throw new TypeError('Limit mutator expects a positive integer')
+  }
+
+  return async function * mutatorLimit (iterable) {
+    for await (const entity of iterable) {
+      if (n-- > 0) {
+        yield entity
+      } else {
+        break
+      }
+    }
   }
 }

--- a/lib/mutators.spec.mjs
+++ b/lib/mutators.spec.mjs
@@ -1,39 +1,60 @@
 import test from 'ava'
 
 import { Entity } from './entity.mjs'
-import { assign, ensure, update } from './mutators.mjs'
+import {
+  assign,
+  ddelete,
+  ensure,
+  limit,
+  skip,
+  update
+} from './mutators.mjs'
 
-function read (...values) {
-  return values.map(Entity.read)
-}
-
-const context = {
-  hooks: {
-    onFind: [],
-    onFilter: [],
-    onEntity: [],
-    beforeCreate: [],
-    beforeUpdate: [],
-    beforeDelete: [],
-    afterCreate: [],
-    afterUpdate: [],
-    afterDelete: []
+function mockFilterContext () {
+  return {
+    adapter: {},
+    argument: undefined,
+    commitMode: 'AUTO',
+    handlers: [],
+    hooks: {
+      onFind: [],
+      onFilter: [],
+      onEntity: [],
+      beforeCreate: [],
+      beforeUpdate: [],
+      beforeDelete: [],
+      afterCreate: [],
+      afterUpdate: [],
+      afterDelete: []
+    },
+    intent: 'FILTER',
+    multiple: true,
+    mutators: [],
+    opaque: undefined,
+    options: {},
+    writeMode: 'AUTO',
+    writeSize: 16
   }
 }
 
-async function unwrap ({ iterable = [], mutator }) {
+async function unwrap (items, mutator) {
+  const iterable = mutator(
+    items.map(Entity.read),
+    mockFilterContext()
+  )
+
   const results = []
-  for await (const entity of mutator(iterable, context)) {
+  for await (const entity of iterable) {
     results.push(entity)
   }
   return results
 }
 
-test('mutator:assign', async t => {
-  const out = await unwrap({
-    iterable: read({ id: 0 }),
-    mutator: assign({ a: true, b: 42 }, { a: undefined, c: true })
-  })
+test('assign', async t => {
+  const out = await unwrap(
+    [{ id: 0 }],
+    assign({ a: true, b: 42 }, { a: undefined, c: true })
+  )
   t.is(out.length, 1)
   t.true(out[0] instanceof Entity)
   t.true(out[0].updated)
@@ -48,66 +69,103 @@ test('mutator:assign', async t => {
   })
 })
 
-test('mutator:update', async t => {
-  const out = await unwrap({
-    iterable: read(41.9),
-    mutator: update((value, index) => {
+test('update', async t => {
+  const out = await unwrap(
+    [41.9],
+    update((value, index) => {
       t.is(index, 0)
       return Math.round(value)
     })
-  })
+  )
   t.is(out.length, 1)
   t.true(out[0] instanceof Entity)
-  t.true(out[0].updated)
-  t.is(out[0].source, 41.9)
-  t.is(out[0].target, 42)
+  t.like(out[0], {
+    updated: true,
+    source: 41.9,
+    target: 42
+  })
 })
 
-test('mutator:ensure', async t => {
-  const yEnsure = await unwrap({
-    iterable: [],
-    mutator: ensure(42)
-  })
+test('ensure smoke test', async t => {
+  const yEnsure = await unwrap([], ensure(42))
   t.is(yEnsure.length, 1)
   t.is(yEnsure[0].valueOf(), 42)
 
-  const fEnsure = await unwrap({
-    iterable: [4, 2],
-    mutator: ensure(-1)
-  })
+  const fEnsure = await unwrap([4, 2], ensure(-1))
   t.is(fEnsure.length, 2)
   t.is(fEnsure[0].valueOf(), 4)
   t.is(fEnsure[1].valueOf(), 2)
 })
 
-test('mutator:ensure-argument', async t => {
+test('ensure argument type', async t => {
   t.plan(12)
 
-  const [a] = await unwrap({
-    mutator: ensure('Hello World!')
-  })
+  const [a] = await unwrap([], ensure('Hello World!'))
   t.true(a instanceof Entity)
   t.true(a.created)
   t.is(a.valueOf(), 'Hello World!')
 
-  const [b] = await unwrap({
-    mutator: ensure(Promise.resolve('Ciao mondo!'))
-  })
+  const [b] = await unwrap([], ensure(Promise.resolve('Ciao mondo!')))
   t.true(b instanceof Entity)
   t.true(b.created)
   t.is(b.valueOf(), 'Ciao mondo!')
 
-  const [c] = await unwrap({
-    mutator: ensure(() => 'Hallo Welt!')
-  })
+  const [c] = await unwrap([], ensure(() => 'Hallo Welt!'))
   t.true(c instanceof Entity)
   t.true(c.created)
   t.is(c.valueOf(), 'Hallo Welt!')
 
-  const [d] = await unwrap({
-    mutator: ensure(() => Promise.resolve('¡Hola Mundo!'))
-  })
+  const [d] = await unwrap([], ensure(() => Promise.resolve('¡Hola Mundo!')))
   t.true(d instanceof Entity)
   t.true(d.created)
   t.is(d.valueOf(), '¡Hola Mundo!')
+})
+
+test('skip', async t => {
+  t.throws(() => skip(-1))
+
+  const entities = await unwrap(
+    ['a', 'b', 'c', 'd', 'e'],
+    skip(2)
+  )
+
+  t.like(entities, [
+    { target: 'c' },
+    { target: 'd' },
+    { target: 'e' }
+  ])
+})
+
+test('limit', async t => {
+  t.throws(() => limit(-1))
+  t.throws(() => limit(0))
+
+  const entities = await unwrap(
+    ['a', 'b', 'c', 'd', 'e'],
+    limit(2)
+  )
+
+  t.like(entities, [
+    { source: 'a', target: 'a' },
+    { source: 'b', target: 'b' }
+  ])
+})
+
+test('ddelete', async t => {
+  const all = await unwrap(['a', 'b'], ddelete())
+  t.like(all, [
+    { deleted: true, target: 'a' },
+    { deleted: true, target: 'b' }
+  ])
+
+  const group = await unwrap(
+    ['c', 'd', 'e', 'f'],
+    ddelete((data, index) => index % 2 === 0)
+  )
+  t.like(group, [
+    { deleted: true, target: 'c' },
+    { deleted: false, target: 'd' },
+    { deleted: true, target: 'e' },
+    { deleted: false, target: 'f' }
+  ])
 })

--- a/lib/options.mjs
+++ b/lib/options.mjs
@@ -1,3 +1,5 @@
+import { isPositiveInteger } from './util.mjs'
+
 const knownHooks = [
   'onFind',
   'onFilter',
@@ -72,7 +74,7 @@ export function parseWriteMode (value = 'AUTO') {
 }
 
 export function parseWriteSize (value = 16) {
-  if (!Number.isInteger(value) || value <= 0) {
+  if (!isPositiveInteger(value)) {
     throw new TypeError('Write size must be a positive integer')
   }
   return value

--- a/lib/store.mjs
+++ b/lib/store.mjs
@@ -7,46 +7,37 @@ import {
   parseWriteMode,
   parseWriteSize
 } from './options.mjs'
+import { isIterable, isObjectLike } from './util.mjs'
 
 export class Store {
-  constructor (options) {
-    const {
-      adapter,
-      commitMode,
-      handlers,
-      hooks,
-      mutators,
-      plugins,
-      writeMode,
-      writeSize
-    } = Object(options)
+  get raw () {
+    return this.adapter.raw
+  }
 
-    if (!adapter) {
-      throw new Error('Adapter is required')
+  constructor (options) {
+    if (!isObjectLike(options)) {
+      throw new TypeError('Expected Store options object')
+    }
+    if (!isObjectLike(options.adapter)) {
+      throw new TypeError('Exepcted Store adapter')
     }
 
-    // Save (valid) defaults
-    this.adapter = adapter
+    // Set defaults
+    this.adapter = options.adapter
     this.commitMode = 'AUTO'
     this.handlers = []
     this.hooks = normalizeHooks()
+    this.mutable = options.mutable === true
     this.mutators = []
     this.writeMode = 'AUTO'
     this.writeSize = 16
 
     // Parse and save submitted options
-    this.register({
-      commitMode,
-      handlers,
-      hooks,
-      mutators,
-      writeMode,
-      writeSize
-    })
+    this.register(options)
 
     // Register plugins
-    if (Array.isArray(plugins)) {
-      for (const plugin of plugins) {
+    if (isIterable(options.plugins)) {
+      for (const plugin of options.plugins) {
         this.register(plugin)
       }
     }
@@ -56,7 +47,47 @@ export class Store {
     return this.mutation('CREATE', data)
   }
 
+  filter (query) {
+    return this.mutation('FILTER', query)
+  }
+
+  find (query) {
+    return this.mutation('FIND', query)
+  }
+
+  from (data) {
+    return this.mutation('FROM', data)
+  }
+
+  mutation (intent, argument) {
+    const mut = new Mutation({
+      adapter: this.adapter,
+      argument,
+      commitMode: this.commitMode,
+      handlers: this.handlers,
+      hooks: this.hooks,
+      intent,
+      multiple: undefined,
+      mutators: this.mutators,
+      opaque: undefined,
+      options: undefined,
+      writeMode: this.writeMode,
+      writeSize: this.writeSize
+    })
+    if (this.mutable) {
+      mut.mutable = true
+    }
+    return mut
+  }
+
+  read (query) {
+    return this.mutation('READ', query)
+  }
+
   register (plugin) {
+    if (!isObjectLike(plugin)) {
+      throw new TypeError('A plugin must be an object')
+    }
     const {
       commitMode,
       handlers,
@@ -64,7 +95,7 @@ export class Store {
       mutators,
       writeMode,
       writeSize
-    } = Object(plugin)
+    } = plugin
 
     if (commitMode !== undefined) {
       this.commitMode = parseCommitMode(commitMode)
@@ -86,35 +117,5 @@ export class Store {
     }
 
     return this
-  }
-
-  filter (query) {
-    return this.mutation('FILTER', query)
-  }
-
-  find (query) {
-    return this.mutation('FIND', query)
-  }
-
-  from (data) {
-    return this.mutation('FROM', data)
-  }
-
-  mutation (intent, argument) {
-    return new Mutation({
-      adapter: this.adapter,
-      argument,
-      commitMode: this.commitMode,
-      handlers: this.handlers,
-      hooks: this.hooks,
-      intent,
-      mutators: this.mutators,
-      writeMode: this.writeMode,
-      writeSize: this.writeSize
-    })
-  }
-
-  read (query) {
-    return this.mutation('READ', query)
   }
 }

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -1,7 +1,23 @@
+export function isObjectLike (value) {
+  return typeof value === 'object' && value !== null
+}
+
 export function isAsyncIterable (value) {
-  return typeof value === 'object' && value !== null && Symbol.asyncIterator in value
+  return isObjectLike(value) && Symbol.asyncIterator in value
 }
 
 export function isIterable (value) {
-  return typeof value === 'object' && value !== null && Symbol.iterator in value
+  return isObjectLike(value) && Symbol.iterator in value
+}
+
+export function isFunction (value) {
+  return typeof value === 'function'
+}
+
+export function isPositiveInteger (value) {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+export function passthrough (value) {
+  return value
 }

--- a/mutent.spec.mjs
+++ b/mutent.spec.mjs
@@ -3,9 +3,10 @@ import { Readable } from 'stream'
 
 import { Entity, MutentError, Store } from './mutent.mjs'
 
-function createAdapter (items = []) {
+function fromArray (items = []) {
   return {
     [Symbol.for('adapter-name')]: 'Array Adapter',
+    raw: items,
     find (predicate) {
       return items.find(predicate)
     },
@@ -52,7 +53,7 @@ test('store:defaults', t => {
 test('store:create', async t => {
   const items = []
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   const huey = { id: 0, name: 'Huey Duck' }
@@ -113,7 +114,7 @@ test('store:find', async t => {
     { id: 2, name: 'Dormouse' }
   ]
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   t.is(await store.find(item => item.id === 0).unwrap(), items[0])
@@ -130,7 +131,7 @@ test('store:find', async t => {
 test('store:read', async t => {
   const items = [{ id: 0, name: 'Tom Orvoloson Riddle', nose: false }]
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   t.is(await store.read(item => item.nose !== true).unwrap(), items[0])
@@ -157,7 +158,7 @@ test('store:filter', async t => {
     { id: 6, name: 'Thaddeus Plotz ', gender: 'male', human: true }
   ]
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   const a = await store.filter(item => item.protagonist === true).unwrap()
@@ -177,7 +178,7 @@ test('hooks:find', async t => {
   t.plan(2)
 
   const store = new Store({
-    adapter: createAdapter(),
+    adapter: fromArray(),
     hooks: {
       onFind (query, context) {
         t.true(typeof query === 'function')
@@ -193,7 +194,7 @@ test('hooks:filter', async t => {
   t.plan(2)
 
   const store = new Store({
-    adapter: createAdapter(),
+    adapter: fromArray(),
     hooks: {
       onFilter (query, context) {
         t.true(typeof query === 'function')
@@ -211,7 +212,7 @@ test('hooks:data', async t => {
   let expectedIntent
 
   const store = new Store({
-    adapter: createAdapter(),
+    adapter: fromArray(),
     hooks: {
       onEntity (entity, context) {
         t.is(context.intent, expectedIntent)
@@ -243,7 +244,7 @@ test('hooks:create', async t => {
   t.plan(4)
 
   const store = new Store({
-    adapter: createAdapter(),
+    adapter: fromArray(),
     hooks: {
       beforeCreate (entity, context) {
         t.deepEqual(entity.target, { a: 'document' })
@@ -263,7 +264,7 @@ test('hooks:update', async t => {
   t.plan(6)
 
   const store = new Store({
-    adapter: createAdapter([{ a: 'document' }]),
+    adapter: fromArray([{ a: 'document' }]),
     hooks: {
       beforeUpdate (entity, context) {
         t.deepEqual(entity.source, { a: 'document' })
@@ -288,7 +289,7 @@ test('hooks:delete', async t => {
   t.plan(4)
 
   const store = new Store({
-    adapter: createAdapter([{ a: 'document' }]),
+    adapter: fromArray([{ a: 'document' }]),
     hooks: {
       beforeDelete (entity, context) {
         t.deepEqual(entity.source, { a: 'document' })
@@ -311,7 +312,7 @@ test('store:safe-commit', async t => {
   const items = []
 
   const store = new Store({
-    adapter: createAdapter(items),
+    adapter: fromArray(items),
     commitMode: 'SAFE'
   })
 
@@ -334,7 +335,7 @@ test('store:manual-commit', async t => {
   const items = []
 
   const store = new Store({
-    adapter: createAdapter(items),
+    adapter: fromArray(items),
     commitMode: 'MANUAL'
   })
 
@@ -373,7 +374,7 @@ test('store:opaque', async t => {
   t.plan(1)
 
   const store = new Store({
-    adapter: createAdapter()
+    adapter: fromArray()
   })
 
   await store
@@ -395,7 +396,7 @@ test('store:tap', async t => {
   const items = [{ my: 'document' }]
 
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   const results = await store
@@ -415,7 +416,7 @@ test('store:filter-mutator', async t => {
   const items = [{ name: 'Shrek' }, { name: 'Fiona' }, { name: 'Donkey' }]
 
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   const results = await store
@@ -476,7 +477,7 @@ test('store:consume', async t => {
   const items = []
 
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   const count = await store.create({ value: 42 }).consume()
@@ -557,7 +558,7 @@ test('store:register', async t => {
 
 test('store:overflow', async t => {
   const store = new Store({
-    adapter: createAdapter(['a']),
+    adapter: fromArray(['a']),
     name: 'test',
     mutators: [
       async function * (iterable) {
@@ -585,7 +586,7 @@ test('store:ensure', async t => {
   const items = []
 
   const store = new Store({
-    adapter: createAdapter(items),
+    adapter: fromArray(items),
     hooks: {
       onEntity (entity) {
         t.is(entity.valueOf(), 42)
@@ -608,7 +609,7 @@ test('store:null-update', async t => {
   ]
 
   const store = new Store({
-    adapter: createAdapter(items),
+    adapter: fromArray(items),
     hooks: {
       beforeUpdate () {
         t.fail()
@@ -628,7 +629,7 @@ test('from with null and undefined', async t => {
   const items = []
 
   const store = new Store({
-    adapter: createAdapter(items)
+    adapter: fromArray(items)
   })
 
   t.deepEqual(items, [])
@@ -644,7 +645,7 @@ test('from with null and undefined', async t => {
 
 test('nullish values with from method', async t => {
   const store = new Store({
-    adapter: createAdapter([
+    adapter: fromArray([
       { id: 1 }
     ])
   })
@@ -798,4 +799,22 @@ test('store handlers', async t => {
 
   const result = await store.create('Oh no').unwrap()
   t.is(result, null)
+})
+
+test('mutable store', async t => {
+  t.plan(3)
+
+  const store = new Store({
+    adapter: fromArray(),
+    mutable: true
+  })
+
+  const mutation = store.create({})
+
+  const m = mutation.assign({ hello: 'world' })
+  t.true(m === mutation)
+
+  const obj = await mutation.unwrap()
+  t.like(obj, { hello: 'world' })
+  t.like(store.raw, [{ hello: 'world' }])
 })

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   "author": "Giacomo Gregoletto",
   "license": "MIT",
   "devDependencies": {
-    "ava": "^6.1.1",
-    "c8": "^9.1.0",
+    "ava": "^6.1.3",
+    "c8": "^10.1.2",
     "docsify-cli": "^4.4.4",
-    "rollup": "^4.10.0",
+    "rollup": "^4.20.0",
     "standard": "^17.1.0"
   },
   "repository": {


### PR DESCRIPTION
## Breaking changes

- Rework type declarations (this doesn't break the core funcionality).
  - Remove second generic from `Lazy` type.
  - Remove `OneOrMore` type.
  - Rename `Result` type to `One`.
  - Query hooks now accepts `undefined` queries (this is a fix).
- Remove `options` field from thrown errors (was `error.info.options`).

## Features

- Better arguments validation.
- Support Adapter's `findEntity` and `filterEntities` methods.
- Add `skip(n)` mutator.
- Add `limit(n)` mutator.
- Add `mutable` flag to `Mutation` class (inherit from `Store`'s `mutable` option).
- Make the `delete(predicate)` mutator conditional.
- Add `raw` getter to `Store` class (returns the Adapter's `raw` property).